### PR TITLE
Fixed Content-Length header creation for data set via magic method

### DIFF
--- a/classes/ProxyRequest.php
+++ b/classes/ProxyRequest.php
@@ -218,9 +218,9 @@ class ProxyRequest
 		if ($strData)
 		{
 			$this->strData = $strData;
-			$default['Content-Length'] = 'Content-Length: '. strlen($this->strData);
 		}
-
+		$default['Content-Length'] = 'Content-Length: '. strlen($this->strData);
+		
 		if ($strMethod)
 		{
 			$this->strMethod = strtoupper($strMethod);


### PR DESCRIPTION
Currently the Content-Length header is only created if data is directly passed to the send() function.
I've moved the header creation out of the if condition for the $strData check, so that the header is also created if the data was set previously via the magic method (e.g. $request->data = $data).